### PR TITLE
Enable RDFa

### DIFF
--- a/index.html
+++ b/index.html
@@ -11,7 +11,7 @@
     <script class='remove'>
 //make tidy happy
     var respecConfig = {
-        doRDFa: false,
+        doRDFa: true,
         previousPublishDate: "2013-12-17",
         specStatus: 'WD',
         shortName: 'appmanifest',


### PR DESCRIPTION
This configuration of this document had explicitly disabled RDFa generation.  Embedding RDFa in W3C specifications increases their processability by knowledge engines, and the RDFa support in ReSpec is mature and stable.  Please enable this support.
